### PR TITLE
New function showNormal

### DIFF
--- a/spectra_lexer/app_plover.py
+++ b/spectra_lexer/app_plover.py
@@ -79,6 +79,9 @@ class PloverPlugin:
     def show(self) -> None:
         self._app.show()
 
+    def showNormal(self) -> None:
+        self._app.show()
+
     def close(self) -> None:
         self._app.close()
 


### PR DESCRIPTION
* spectra_lexer/app_plover.py (PloverPlugin.showNormal): Plover's
gui_qt/main_window.py calls showNormal from _activate_dialog and other
functions, so this takes care of showing the Spectra dialog.

I had this weird problem where I could only start the Spectra plugin once. If I closed it, I couldn't open it again. It looks like main_window.py calls showNormal instead of show. This change allows me to open and close Spectra as many times as I need to while Plover is open.