### PR TITLE
Fix layout bug WR (brief for WERE) displayed over wrong keys.

### DIFF
--- a/spectra_lexer/assets/board_defs.cson
+++ b/spectra_lexer/assets/board_defs.cson
@@ -271,7 +271,7 @@
     "PH":     {"pos": "P",  "shape": "rect"},
     "SK":     {"pos": "S2", "shape": "wide"},
     "KW":     {"pos": "K",  "shape": "wide"},
-    "WR":     {"pos": "K",  "shape": "wide"},
+    "WR":     {"pos": "W",  "shape": "wide"},
     "AO":     {"pos": "A",  "shape": "wide"},
     "EU":     {"pos": "E",  "shape": "wide"},
     "fp":     {"pos": "f",  "shape": "rect"},


### PR DESCRIPTION
Addresses https://github.com/fourshade/spectra_lexer/issues/13

I tested this locally, and it looks like it works. 

I don't know if there are any other changes that need to coordinate with the one-character change to the `board_defs.cson` file. But if there are, let me know and I can tweak this.