### PR TITLE
Migrate to PySide6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ lib
 .idea
 .cache
 .local
+
+# Python virtual environments
+.venv
+venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-	"PyQt5>=5.14",
+	"PySide6-Essentials>=6.9.0",
 	"setuptools>=42",
 	"wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spectra_lexer
-version = 16.1.1
+version = 17.0.0
 description = Stroke and rule analyzer for stenography
 long_description = file: README.rst
 author = fourshade
@@ -24,9 +24,9 @@ keywords = plover plover_plugin
 
 [options]
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.10
 install_requires =
-    PyQt5>=5.5
+    PySide6-Essentials>=6.9.0
 tests_require =
     pytest
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ import sys
 
 from setuptools import Command as stCommand, setup
 from setuptools.command import develop, install, sdist
+from wheel import bdist_wheel
+
 
 
 def iglob_all(*patterns):
@@ -47,15 +49,14 @@ class CommandNamespace:
 
     class build_ui(Command):
         description = "Build Python code from new/modified Qt UI files."
-        requires = "clean"
+        requires = ""
         def run(self):
             for src in iglob_all('**/*.ui'):
                 dst = os.path.splitext(src)[0] + '_ui.py'
                 if os.path.exists(dst) and os.path.getmtime(dst) >= os.path.getmtime(src):
                     continue
-                cmd = (sys.executable, '-m', 'PyQt5.uic.pyuic', '--from-import', src)
-                with open(dst, 'w') as fp:
-                    subprocess.run(cmd, stdout=fp, text=True)
+                cmd = ('pyside6-uic', '--from-imports', src,'-o',dst)
+                subprocess.run(cmd, text=True)
 
     class clean(Command):
         description = "Remove all build and test-generated files."
@@ -70,6 +71,9 @@ class CommandNamespace:
         requires = "build_ui"
 
     class install(BaseCommand, install.install):
+        requires = "build_ui"
+
+    class bdist_wheel(BaseCommand, bdist_wheel.bdist_wheel):
         requires = "build_ui"
 
     class run(Command):

--- a/spectra_lexer/app_plover.py
+++ b/spectra_lexer/app_plover.py
@@ -4,6 +4,7 @@ from spectra_lexer import Spectra, SpectraOptions
 from spectra_lexer.app_qt import build_app
 from spectra_lexer.plover.plugin import EngineWrapper, IPlover, PloverExtension
 from spectra_lexer.qt import ICON_PACKAGE, ICON_PATH
+from importlib.resources import files as _res_files
 
 
 class _Dummy:
@@ -23,7 +24,8 @@ class PloverPlugin:
     # Class constants required by Plover for toolbar.
     __doc__ = 'See the breakdown of words using steno rules.'
     TITLE = 'Spectra'
-    ICON = ':'.join(['asset', ICON_PACKAGE, ICON_PATH])
+    # loading the icon this way so we don't need to compile a Qt resource bundle (.qrc)
+    ICON = str((_res_files(ICON_PACKAGE) / ICON_PATH))
     ROLE = 'spectra_dialog'
     SHORTCUT = 'Ctrl+Shift+L'
 

--- a/spectra_lexer/app_qt.py
+++ b/spectra_lexer/app_qt.py
@@ -2,7 +2,7 @@ import pkgutil
 import sys
 from typing import Callable, Sequence
 
-from PyQt5.QtWidgets import QDialog, QMainWindow
+from PySide6.QtWidgets import QDialog, QMainWindow
 
 from spectra_lexer import Spectra
 from spectra_lexer.config.main import QtConfigManager

--- a/spectra_lexer/config/qt.py
+++ b/spectra_lexer/config/qt.py
@@ -1,8 +1,7 @@
 """ Module for Qt GUI config manager. """
 
-from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QFormLayout, QFrame, QLabel, QLineEdit, QMessageBox, \
-    QTabWidget, QVBoxLayout, QWidget
+from PySide6.QtCore import Signal, Qt
+from PySide6.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QFormLayout, QFrame, QLabel, QLineEdit, QMessageBox,     QTabWidget, QVBoxLayout, QWidget
 
 from .spec import ConfigDict, ConfigSpec, Option, Section, SectionDict
 
@@ -71,9 +70,9 @@ class ConfigTabWidget(QTabWidget):
 class ConfigDialog(QDialog):
     """ Qt config manager dialog with an option tab widget and standard submission form buttons. """
 
-    WINDOW_FLAGS = Qt.CustomizeWindowHint | Qt.Dialog | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
+    WINDOW_FLAGS = (Qt.WindowType.CustomizeWindowHint | Qt.WindowType.Dialog | Qt.WindowType.WindowCloseButtonHint | Qt.WindowType.WindowTitleHint)
 
-    submitted = pyqtSignal([dict])  # Signal to return config values on dialog accept.
+    submitted = Signal(dict)  # Signal to return config values on dialog accept.
 
     def __init__(self, parent:QWidget=None, flags=WINDOW_FLAGS) -> None:
         super().__init__(parent, flags)
@@ -82,7 +81,7 @@ class ConfigDialog(QDialog):
         self.setMaximumSize(250, 300)
         self._tabs = ConfigTabWidget(self)
         button_box = QDialogButtonBox(self)
-        button_box.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box.setStandardButtons(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         button_box.setCenterButtons(True)
         button_box.accepted.connect(self._submit)
         button_box.rejected.connect(self.reject)

--- a/spectra_lexer/console/main.py
+++ b/spectra_lexer/console/main.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import pyqtSignal
+from PySide6.QtCore import Signal
 
 from . import introspect
 from .qt import TerminalDialog
@@ -9,8 +9,8 @@ class ConsoleDialog(TerminalDialog):
     """ Qt console dialog tool. Useful for live inspection of a Python object.
         All reads and writes are done with signals for thread safety. """
 
-    _sig_write = pyqtSignal([str])  # Emitted to write output text using the main thread.
-    _sig_close = pyqtSignal([])     # Emitted to close the dialog using the main thread.
+    _sig_write = Signal(str)  # Emitted to write output text using the main thread.
+    _sig_close = Signal()     # Emitted to close the dialog using the main thread.
 
     write_limit = 100000  # Maximum number of characters to add in one write without cropping.
 

--- a/spectra_lexer/main_qt.py
+++ b/spectra_lexer/main_qt.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from PyQt5.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication
 
 from spectra_lexer import Spectra, SpectraOptions
 from spectra_lexer.app_qt import build_app
@@ -18,7 +18,7 @@ def main() -> int:
         app.start()
     except Exception as e:
         sys.excepthook(type(e), e, e.__traceback__)
-    return q_app.exec_()
+    return q_app.exec()
 
 
 if __name__ == '__main__':

--- a/spectra_lexer/plover/plugin.py
+++ b/spectra_lexer/plover/plugin.py
@@ -11,7 +11,7 @@ StringStenoDict = Dict[str, str]         # Dict of string-keyed Plover translati
 class IPlover:
     """ Data types and interfaces containing only what is necessary for compatibility with Plover. """
 
-    VERSION = "4.0.0.dev8"  # Plover version for which these interfaces are known to be valid.
+    VERSION = "5.0.0.dev3"  # Plover version for which these interfaces are known to be valid.
 
     class IncompatibleError(Exception):
         """ Raised if the installed Plover version is not compatible with this application. """

--- a/spectra_lexer/qt/board.py
+++ b/spectra_lexer/qt/board.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QColor, QContextMenuEvent, QGuiApplication, QImage, QPaintDevice, QPainter, QPixmap
-from PyQt5.QtWidgets import QMenu, QWidget
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QColor, QContextMenuEvent, QGuiApplication, QImage, QPaintDevice, QPainter, QPixmap
+from PySide6.QtWidgets import QMenu, QWidget
 
 from .svg import QtSVGData, SVGEngine
 
@@ -29,7 +29,7 @@ class BoardWidget(QWidget):
     PAINT_BG = QColor(0, 0, 0, 0)         # Transparent background for widget painting.
     COPY_BG = QColor(255, 255, 255, 255)  # White background for the clipboard.
 
-    resized = pyqtSignal()
+    resized = Signal()
 
     def __init__(self, *args) -> None:
         super().__init__(*args)

--- a/spectra_lexer/qt/dialog.py
+++ b/spectra_lexer/qt/dialog.py
@@ -1,7 +1,7 @@
 from typing import Callable, List
 from weakref import WeakValueDictionary
 
-from PyQt5.QtWidgets import QDialog, QFileDialog, QMessageBox, QWidget
+from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox, QWidget
 
 DialogOpener = Callable[[], QDialog]
 
@@ -42,7 +42,7 @@ class DialogManager:
 
     def yes_or_no(self, title:str, message:str) -> bool:
         """ Present a modal yes/no dialog and return the user's response as True/False. """
-        yes, no = QMessageBox.Yes, QMessageBox.No
+        yes, no = QMessageBox.StandardButton.Yes, QMessageBox.StandardButton.No
         button = QMessageBox.question(self._parent, title, message, yes | no)
         return button == yes
 

--- a/spectra_lexer/qt/graph.py
+++ b/spectra_lexer/qt/graph.py
@@ -1,13 +1,13 @@
-from PyQt5.QtCore import QUrl, pyqtSignal
-from PyQt5.QtGui import QTextCharFormat
-from PyQt5.QtWidgets import QTextBrowser
+from PySide6.QtCore import QUrl, Signal
+from PySide6.QtGui import QTextCharFormat
+from PySide6.QtWidgets import QTextBrowser
 
 
 class GraphWidget(QTextBrowser):
     """ GUI panel for displaying a monospaced HTML graph of the breakdown of text by steno rules.
         May also display plaintext output such as error messages and exceptions when necessary. """
 
-    selected = pyqtSignal([str, bool])  # Emitted with the ref string under the cursor and the focus state.
+    selected = Signal(str, bool)  # Emitted with the ref string under the cursor and the focus state.
 
     def __init__(self, *args) -> None:
         super().__init__(*args)

--- a/spectra_lexer/qt/index_dialog.py
+++ b/spectra_lexer/qt/index_dialog.py
@@ -1,12 +1,17 @@
 from typing import Callable
 
-from PyQt5.QtCore import QObject, Qt
-from PyQt5.QtWidgets import QDialog, QLabel, QWidget
+from PySide6.QtCore import QObject, Qt
+from PySide6.QtWidgets import QDialog, QLabel, QWidget
 
 from .index_dialog_ui import Ui_IndexSizeDialog
 
 SizeCallback = Callable[[int], None]
-WINDOW_FLAGS = Qt.CustomizeWindowHint | Qt.Dialog | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
+WINDOW_FLAGS = (
+    Qt.WindowType.CustomizeWindowHint
+    | Qt.WindowType.Dialog
+    | Qt.WindowType.WindowCloseButtonHint
+    | Qt.WindowType.WindowTitleHint
+)
 
 
 class SliderInfo(QObject):

--- a/spectra_lexer/qt/main_window.py
+++ b/spectra_lexer/qt/main_window.py
@@ -1,6 +1,6 @@
 from typing import Callable, Sequence
 
-from PyQt5.QtWidgets import QCheckBox, QLabel, QMainWindow, QMenuBar, QSlider
+from PySide6.QtWidgets import QCheckBox, QLabel, QMainWindow, QMenuBar, QSlider
 
 from .board import BoardWidget
 from .graph import GraphWidget

--- a/spectra_lexer/qt/system.py
+++ b/spectra_lexer/qt/system.py
@@ -3,7 +3,7 @@
 from queue import Queue
 from typing import Callable, NoReturn
 
-from PyQt5.QtCore import pyqtSignal, QThread
+from PySide6.QtCore import Signal, QThread
 
 
 def _apply(func:Callable, args:tuple) -> None:
@@ -17,7 +17,7 @@ def _raise(exc:Exception) -> NoReturn:
 class QtTaskExecutor(QThread):
     """ Worker thread that executes long-running operations from a queue. """
 
-    _sig_call_main = pyqtSignal([object, tuple])  # Allows this thread to apply functions on the main event loop.
+    _sig_call_main = Signal(object, tuple)  # Allows this thread to apply functions on the main event loop.
 
     def __init__(self, *args) -> None:
         super().__init__(*args)

--- a/spectra_lexer/qt/title.py
+++ b/spectra_lexer/qt/title.py
@@ -1,14 +1,14 @@
 from itertools import cycle
 from typing import Sequence
 
-from PyQt5.QtCore import pyqtSignal, QTimer
-from PyQt5.QtWidgets import QLineEdit
+from PySide6.QtCore import Signal, QTimer
+from PySide6.QtWidgets import QLineEdit
 
 
 class TitleWidget(QLineEdit):
     """ Title bar widget that displays plaintext as well as simple text animations. """
 
-    submitted = pyqtSignal([str])  # Emitted with the widget's current text when Enter is pressed.
+    submitted = Signal(str)  # Emitted with the widget's current text when Enter is pressed.
 
     def __init__(self, *args) -> None:
         super().__init__(*args)

--- a/spectra_lexer/qt/window.py
+++ b/spectra_lexer/qt/window.py
@@ -1,12 +1,12 @@
-from PyQt5.QtCore import pyqtSignal, QEvent, QObject
-from PyQt5.QtGui import QIcon, QPixmap
-from PyQt5.QtWidgets import QApplication, QMainWindow
+from PySide6.QtCore import Signal, QEvent, QObject
+from PySide6.QtGui import QIcon, QPixmap
+from PySide6.QtWidgets import QApplication, QMainWindow
 
 
 class WindowController(QObject):
     """ Wrapper class with methods for manipulating the main window. """
 
-    activated = pyqtSignal()  # Emitted when the window state changes from inactive to active.
+    activated = Signal()  # Emitted when the window state changes from inactive to active.
 
     def __init__(self, w_window:QMainWindow) -> None:
         super().__init__(w_window)
@@ -14,7 +14,7 @@ class WindowController(QObject):
         w_window.installEventFilter(self)
 
     def eventFilter(self, _, event:QEvent) -> bool:
-        if event.type() == QEvent.WindowActivate:
+        if event.type() == QEvent.Type.WindowActivate:
             self.activated.emit()
         return False
 
@@ -24,7 +24,7 @@ class WindowController(QObject):
         self._w_window.show()
         self._w_window.activateWindow()
         self._w_window.raise_()
-        QApplication.instance().processEvents()
+        QApplication.processEvents()
 
     def close(self) -> None:
         self._w_window.close()


### PR DESCRIPTION
Migrate the plugin to PySide6 to support Plover v5.

Most changes are straightforward but here are some things that you might want to have a closer look at:
*  `spectra_lexer/app_plover.py`: changed the logic how the ICON is loaded, see the comment there
* `setup.py`: remove the `requires = "clean"` because Plover was complaining that the `egg-info` was missing when installing with `tox r -e plugins_install -- ../spectra_lexer` since the clean was running too late in the process. I tried a bunch of things but I'm sure you know better how this works
* `setup.py`: added `class bdist_wheel(BaseCommand, bdist_wheel.bdist_wheel):` or otherwise the installation via URL in the plugins manager doesn't work. That's also true for the current version of spectra_lexer on Plover v4

Something that probably should be tackled in a separate PR: Since Plover v5 supports dark mode, the graph coloring needs to be updated to handle that:
<img width="654" height="586" alt="image" src="https://github.com/user-attachments/assets/0c5875a3-5f06-4d69-81bb-84b0214df615" />


An easy way to install this plugin in Plover v5 is via the GIT button in the Plugins Manager (next to the Install/Update button) using the URL `https://github.com/mkrnr/spectra_lexer@pyside6-migration`

Feel free to edit this PR.